### PR TITLE
Add Doxygen-Sphinx docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+docs/build/
+docs/sphinx/_build/
+__pycache__/
+docs/sphinx/make.bat

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2252,7 +2252,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,0 +1,23 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+doxygen:
+	doxygen ../Doxyfile

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,0 +1,36 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'MINIX3 Mailbox IPC'
+copyright = '2025, Auto'
+author = 'Auto'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'breathe',
+]
+
+breathe_projects = {
+    'MINIX3 Mailbox IPC': '../build/xml'
+}
+breathe_default_project = 'MINIX3 Mailbox IPC'
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/sphinx/doxygen/index.rst
+++ b/docs/sphinx/doxygen/index.rst
@@ -1,0 +1,5 @@
+Doxygen Documentation
+=====================
+
+.. doxygenindex::
+   :project: MINIX3 Mailbox IPC

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,0 +1,28 @@
+.. MINIX3 Mailbox IPC documentation master file, created by
+   sphinx-quickstart on Sun Jun  8 23:49:15 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to MINIX3 Mailbox IPC's documentation!
+==============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+Doxygen
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   doxygen/index


### PR DESCRIPTION
## Summary
- integrate Sphinx with Breathe to include Doxygen XML
- set up `Doxyfile` to generate XML
- provide Sphinx configuration and docs skeleton
- ignore built documentation

## Testing
- `doxygen docs/Doxyfile`
- `make html` in `docs/sphinx`


------
https://chatgpt.com/codex/tasks/task_e_684620ffeaf08331aee1dfd46a131f17